### PR TITLE
Random room nums

### DIFF
--- a/actions.pl
+++ b/actions.pl
@@ -27,13 +27,14 @@ arrow_pass_through(PreviousTarget, Targets) :-
 resolve_arrow(PreviousTarget, [Aim|NextTargets]) :- 
     energy(ArrowEnergy),
     ArrowEnergy > 0,
-    (connected(PreviousTarget, Aim),
+    map_room(Aim, ActualAim),
+    (connected(PreviousTarget, ActualAim),
         write("arrow is flying through room "),
         print(Aim), nl,
-        (check_room_for_hit(Aim);
+        (check_room_for_hit(ActualAim);
         
         (list_empty(NextTargets, false),
-        arrow_pass_through(Aim, NextTargets));
+        arrow_pass_through(ActualAim, NextTargets));
         
         write("arrow ran out of kinetic energy and crashed into the ground"), nl)
     );

--- a/hunt_the_wumpus.pl
+++ b/hunt_the_wumpus.pl
@@ -25,13 +25,15 @@ get_input(Input) :- process_input(Input), get_input.
 % move to a different room
 process_input([go, NewRoom]) :-
     current_room(Current),
-    connected(Current, NewRoom),
-    change_room(NewRoom).
+    map_room(NewRoom, ActualRoomNum),
+    connected(Current, ActualRoomNum),
+    change_room(ActualRoomNum).
 
 % shoot an arrow
 process_input([shoot, FirstRoom|OtherRooms]) :-
     current_room(Current),
-    connected(Current, FirstRoom),
+    map_room(FirstRoom, ActualRoomNum),
+    connected(Current, ActualRoomNum),
     shoot_arrow(Current, [FirstRoom|OtherRooms]).
 
 
@@ -55,6 +57,8 @@ play :-
     retractall(quiver(_)),
     retractall(current_room(_)),
 
+    retractall(rand_rooms(_)),
+
     % assign a dummy room at the start
     assertz(current_room(999)),
     assertz(target(999)),
@@ -63,6 +67,10 @@ play :-
     rooms_list(R),
     sample_without_replacement(R, 6, Sample),
     print(Sample), nl,
+
+    % set random room number mapping
+    sample_without_replacement(R, 20, RandRooms),
+    assertz(rand_rooms(RandRooms)),
 
     % add location for Wumpus into KB
     nth1(1, Sample, W),

--- a/math_helpers.pl
+++ b/math_helpers.pl
@@ -6,3 +6,9 @@ sample_without_replacement(Range, N, Sample) :-
     random_permutation(Range, Permutation),
     length(Sample, N),
     append(Sample, _, Permutation).
+
+index_of([Elem|_], Elem, 1):- !.
+index_of([_|Tail], Elem, Index):-
+    index_of(Tail, Elem, Index1),
+    !,
+    Index is Index1 + 1.

--- a/maze.pl
+++ b/maze.pl
@@ -85,3 +85,10 @@ connected(9, 4).
 connected(4, 9).
 connected(4, 5).
 connected(5, 4).
+
+% for testing
+% rand_rooms([13,8,3,6,17,16,1,5,9,7,4,20,2,10,11,19,18,14,15,12]).
+
+map_room(Rand, Actual) :-
+    rand_rooms(RandRooms),
+    nth1(Actual, RandRooms, Rand).

--- a/maze.pl
+++ b/maze.pl
@@ -85,13 +85,3 @@ connected(9, 4).
 connected(4, 9).
 connected(4, 5).
 connected(5, 4).
-
-
-
-
-
-
-
-
-
-

--- a/printer.pl
+++ b/printer.pl
@@ -1,11 +1,13 @@
-
 % prints out current room name and adjacent room names
 print_room :-
     % handle current room name
     current_room(Current),
-    room(Current, Name),
+    map_room(RoomNum, Current),
+    room(RoomNum, Name),
     write("You are in room "),
-    print(Current), nl,
+    print(RoomNum), nl,
+    % uncomment the line below to print the actual room number
+    % write("Actual room num: "), print(Current), nl
     write("Known as "),
     print(Name), nl,
     write("From here tunnels lead to: "), nl,
@@ -15,13 +17,21 @@ print_choices :-
     % handle current room name
     current_room(Current),
     % handle adjacent room names
-    connected(Current, NewRoom1),
-    connected(Current, NewRoom2),
-    connected(Current, NewRoom3),
+    connected(Current, RoomNum1),
+    connected(Current, RoomNum2),
+    connected(Current, RoomNum3),
     % make sure room names are unique
-    dif(NewRoom1, NewRoom2),
-    dif(NewRoom2, NewRoom3),
-    dif(NewRoom1, NewRoom3),
+    dif(RoomNum1, RoomNum2),
+    dif(RoomNum2, RoomNum3),
+    dif(RoomNum1, RoomNum3),
+
+    map_room(NewRoom1, RoomNum1),
+    map_room(NewRoom2, RoomNum2),
+    map_room(NewRoom3, RoomNum3),
+
+    % uncomment the line below to print the actual room numbers
+    % write("Actual choices: "), print([RoomNum1, RoomNum2, RoomNum3]), nl,
+
     print(NewRoom1), nl,
     print(NewRoom2), nl,
     print(NewRoom3), nl.

--- a/senses.pl
+++ b/senses.pl
@@ -49,5 +49,7 @@ senses_check :-
 
    next_to_bat_cave,
    write("I hear'em flapping..."), nl,
+   print_room;
+
    print_room.
 


### PR DESCRIPTION
Assign random numbers to rooms. The logic is still based on the actual room numbers, it only affects what we print. Also fixed the issue where print_room was not executed if there is no bats/pits/wumpus nearby.